### PR TITLE
Add usage instructions for icon enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,6 @@ IconPickerEntry::make('status_icon')
     ->animation(fn ($record) => $record->is_loading ? 'spin' : null)
     ->showIconName(false)
 ```
-```
 
 ### Using Icon Enums
 


### PR DESCRIPTION
Updated the README to include usage instructions for icon enums.