### PR TITLE
feat: add packge hugeicons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `filament-icon-picker` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Support for `afatmustafa/blade-hugeicons` icon package (~4,500 icons)
+- `hugeicons()` method to the `Icon` helper class
+- Automatic prefix detection for `hugeicons-` icons
+
 ## [1.4.4] - 2025-12-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This will show you an interactive menu to select which icon packages to install:
   ○ Material - Google Material Design (~10,000 icons)
   ○ Tabler - Tabler Icons (~4,400 icons)
   ○ Lucide - Lucide Icons (~1,400 icons)
+  ○ Hugeicons - Hugeicons (~4,500 icons)
 ```
 
 **Other options:**
@@ -98,6 +99,9 @@ composer require blade-ui-kit/blade-tabler-icons
 
 # Lucide Icons (1400+ icons)
 composer require mallardduck/blade-lucide-icons
+
+# Hugeicons (4500+ icons)
+composer require afatmustafa/blade-hugeicons
 ```
 
 See all available icon packages at [Blade Icons](https://blade-ui-kit.com/blade-icons#icon-packages).
@@ -184,6 +188,7 @@ Icon::heroicon('users', 'solid')         // heroicon-s-users
 Icon::phosphor('whatsapp-logo', 'duotone') // phosphor-whatsapp-logo-duotone
 Icon::fontawesome('heart', 'solid')      // fas-heart
 Icon::fontawesome('github', 'brands')    // fab-github
+Icon::hugeicons('menu-01')                 // hugeicons-menu-01
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "secondnetwork/blade-tabler-icons": "Tabler Icons - 4400+ icons",
         "mallardduck/blade-lucide-icons": "Lucide Icons - 1400+ icons",
         "davidhsianturi/blade-bootstrap-icons": "Bootstrap Icons - 2000+ icons",
-        "andreiio/blade-remix-icon": "Remix Icons - 2800+ icons"
+        "andreiio/blade-remix-icon": "Remix Icons - 2800+ icons",
+        "afatmustafa/blade-hugeicons": "Hugeicons - 4500+ icons"
     },
     "autoload": {
         "psr-4": {

--- a/src/Commands/InstallIconsCommand.php
+++ b/src/Commands/InstallIconsCommand.php
@@ -76,6 +76,12 @@ class InstallIconsCommand extends Command
             'icons' => '~2,800',
             'sets' => ['remix'],
         ],
+        'hugeicons' => [
+            'package' => 'afatmustafa/blade-hugeicons',
+            'description' => 'Hugeicons',
+            'icons' => '~4,500',
+            'sets' => ['hugeicons'],
+        ],
     ];
 
     public function handle(): int

--- a/src/Enums/Icon.php
+++ b/src/Enums/Icon.php
@@ -128,6 +128,14 @@ class Icon implements ScalableIcon
     }
 
     /**
+     * Create a Hugeicons icon.
+     */
+    public static function hugeicons(string $name): static
+    {
+        return new static("hugeicons-{$name}", 'hugeicons');
+    }
+
+    /**
      * Get the icon name.
      */
     public function getName(): string
@@ -190,6 +198,10 @@ class Icon implements ScalableIcon
 
         if (str_starts_with($name, 'bi-')) {
             return 'bootstrap-icons';
+        }
+
+        if (str_starts_with($name, 'hugeicons-')) {
+            return 'hugeicons';
         }
 
         return 'unknown';

--- a/tests/Unit/IconHelperTest.php
+++ b/tests/Unit/IconHelperTest.php
@@ -104,6 +104,12 @@ final class IconHelperTest extends TestCase
     }
 
     #[Test]
+    public function it_generates_hugeicons(): void
+    {
+        $this->assertEquals('hugeicons-menu-01', (string) Icon::hugeicons('menu-01'));
+    }
+
+    #[Test]
     public function it_can_create_icon_from_full_name(): void
     {
         $icon = Icon::make('heroicon-o-users');
@@ -117,5 +123,6 @@ final class IconHelperTest extends TestCase
         $this->assertEquals('heroicons', Icon::heroicon('users')->getSet());
         $this->assertEquals('google-material-design-icons', Icon::material('home')->getSet());
         $this->assertEquals('phosphor-icons', Icon::phosphor('heart')->getSet());
+        $this->assertEquals('hugeicons', Icon::hugeicons('star')->getSet());
     }
 }


### PR DESCRIPTION

[#4](https://github.com/wallacemartinss/filament-icon-picker/issues/4)
This PR adds official support for the [afatmustafa/blade-hugeicons](https://github.com/afatmustafa/blade-hugeicons) package (~4,500+ icons) to the Filament Icon Picker. It includes updates to the installation command, helper classes, documentation, and unit tests. 


Changes
📦 Integration & Installation
Interactive Installer: Added 

hugeicons
 to the filament-icon-picker:install-icons command. Users can now select and install Hugeicons directly from the interactive menu.
Composer Suggestions: Added afatmustafa/blade-hugeicons to the suggest section in 

composer.json
.
🛠 Helper & Logic Updates
Icon Helper: Added a new 

hugeicons()
 static method to the Wallacemartinss\FilamentIconPicker\Enums\Icon class for fluent usage:
php
Icon::hugeicons('menu-01') // returns 'hugeicons-menu-01'
Automatic Detection: Updated the 

detectSet()
 logic to automatically recognize and categorize icons with the hugeicons- prefix.
🧪 Quality Assurance
Unit Tests: Updated 

IconHelperTest.php
 with new test cases to ensure:
Correct string generation for Hugeicons.
Proper set detection for the Hugeicons prefix.
📝 Documentation
README: Updated with installation instructions and usage examples for the new icon set.
CHANGELOG: Added a new entry under the [Unreleased] section to track these changes.

